### PR TITLE
Handle read timeouts on download with retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # oe-databank
- Python API for using Oxford Economics' OE Databank API.
+
+Python expression of Oxford Economics' Databank API.
+
+## Installation
+
+```bash
+pip install oe-databank
+```
+
+## Usage
+
+Queries can be sent synchronously or asynchronously.
+
+```python
+import asyncio
+from oe_databank import (
+    DatabankAsyncClient,
+    DatabankClient,
+    FileDownloadRequestDto,
+    FileFormat,
+    Frequency,
+    ListingType,
+    Order,
+    Selection,
+    SelectionSortOrder,
+    SelectionType,
+    Sequence,
+)
+
+request = FileDownloadRequestDto(
+    selections=[
+        Selection(
+            selectionType=SelectionType.QUERY,
+            isTemporarySelection=True,
+            databankCode="IST",
+            sequence=Sequence.EARLIEST_TO_LATEST,
+            groupingMode=False,
+            transposeColumns=False,
+            order=Order.LOCATION_INDICATOR,
+            indicatorSortOrder=SelectionSortOrder.ALPHABETICAL,
+            locationSortOrder=SelectionSortOrder.ALPHABETICAL,
+            format=0,
+            legacyDatafeedFileStructure=False,
+            variables=[],
+            regions=[],
+            listingType=ListingType.SHARED,
+            isDataFeed=False,
+            startYear=2023,
+            endYear=2027,
+            precision=5,
+            frequency=Frequency.ANNUAL,
+            stackedQuarters=False,
+        )
+    ],
+    format=FileFormat.CSV,
+    name="test-te-pull",
+)
+
+DatabankClient(api_key=...).query(request=request, to_path="sync_result.csv")
+
+asyncio.run(DatabankAsyncClient(api_key=...).query(request=request, to_path="async_result.csv"))
+```
+
+You might run into issues with large downloads, so you can use retry options to handle errors during download.
+
+```python
+from oe_databank import DatabankClient
+
+DatabankClient(api_key=...).query(
+    request=request,
+    to_path="sync_result.csv",
+    download_attempts=3,
+    download_retry_delay_seconds=2.0,
+)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "pydantic>=2.0.0",
     "orjson>=3.10.7",
+    "tenacity>=9.0.0",
 ]
 
 [build-system]
@@ -22,6 +23,7 @@ build-backend = "hatchling.build"
 dev = [
     "pre-commit==4.0.1",
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.2",
 ]
 
 [tool.pytest.ini_options]

--- a/src/oe_databank/client.py
+++ b/src/oe_databank/client.py
@@ -10,6 +10,7 @@ import httpx
 import httpx._config
 import httpx._types
 import orjson
+import tenacity
 
 from oe_databank.models import (
     DatabankListResponse,
@@ -89,6 +90,8 @@ class DatabankClient:
         download_timeout_seconds: float | int = DEFAULT_DOWNLOAD_TIMEOUT_SECONDS,
         poll_timeout_seconds: float | int = DEFAULT_POLL_TIMEOUT_SECONDS,
         poll_interval_seconds: float | int = DEFAULT_POLL_INTERVAL_SECONDS,
+        download_attempts: int = 3,
+        download_retry_delay_seconds: float | int = 1.0,
     ):
         """Initialize the API.
 
@@ -100,6 +103,8 @@ class DatabankClient:
             download_timeout_seconds (float | int, optional): The total time to wait for a download. Defaults to the client's default.
             poll_timeout_seconds (float | int, optional): The total time to wait for a file to be ready. Defaults to the client's default.
             poll_interval_seconds (float | int, optional): The polling interval in seconds. Defaults to the client's default.
+            download_attempts (int, optional): The maximum number of download attempts. Defaults to 3.
+            download_retry_delay_seconds (float | int, optional): The time to sleep between download retries. Defaults to 1 second.
         """
         self.api_key = api_key
         self.headers = headers or {}
@@ -107,14 +112,27 @@ class DatabankClient:
         # Define before setting the client
         self.timeout = timeout
         self._client = client or self._make_client()
-        self.default_download_timeout_seconds = download_timeout_seconds
         self.default_poll_timeout_seconds = poll_timeout_seconds
         self.default_poll_interval_seconds = poll_interval_seconds
+        # Download settings
+        self.default_download_timeout_seconds = download_timeout_seconds
+        self.download_attempts = download_attempts
+        self.download_retry_delay_seconds = download_retry_delay_seconds
 
     @property
     def raw(self) -> httpx.Client:
         """The underlying HTTP client."""
         return self._client
+
+    @property
+    def __download_retry_wrapper(self):
+        return tenacity.retry(
+            stop=tenacity.stop_after_attempt(self.download_attempts),
+            wait=tenacity.wait_fixed(self.download_retry_delay_seconds),
+            retry=tenacity.retry_if_exception_type(
+                (httpx.NetworkError, httpx.TimeoutException)
+            ),
+        )
 
     def _make_client(self) -> httpx.Client:
         """Create an HTTP client with the API key in the headers."""
@@ -159,7 +177,7 @@ class DatabankClient:
     ) -> bytes | None:
         """Download a file with a file download request in the body."""
         # Must follow redirects as the polling URL is returned until the download is ready.
-        r = self._client.post(
+        r = self.__download_retry_wrapper(self._client.post)(
             "/filedownload",
             content=orjson.dumps(request.model_dump(mode="json")),
             timeout=self._resolve_download_timeout(timeout),
@@ -178,7 +196,7 @@ class DatabankClient:
     ) -> bytes | None:
         """Download a file by selection ID."""
         path = f"/filedownload/{selection_id}"
-        r = self._client.get(
+        r = self.__download_retry_wrapper(self._client.get)(
             path, timeout=self._resolve_download_timeout(timeout), follow_redirects=True
         )
         r.raise_for_status()

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,141 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from oe_databank.async_client import DatabankAsyncClient
+from oe_databank.enums import (
+    FileFormat,
+    Frequency,
+    ListingType,
+    Order,
+    SelectionSortOrder,
+    SelectionType,
+    Sequence,
+)
+from oe_databank.models import FileDownloadRequestDto, QueueDownloadResponse, Selection
+
+
+class TestDatabankAsyncClient:
+    @pytest.fixture
+    def client(self):
+        return DatabankAsyncClient(api_key="test_api_key")
+
+    @pytest.fixture
+    def download_request(self):
+        return FileDownloadRequestDto(
+            selections=[
+                Selection(
+                    selectionType=SelectionType.QUERY,
+                    isTemporarySelection=True,
+                    databankCode="GCT",
+                    sequence=Sequence.EARLIEST_TO_LATEST,
+                    groupingMode=False,
+                    transposeColumns=False,
+                    order=Order.LOCATION_INDICATOR,
+                    indicatorSortOrder=SelectionSortOrder.ALPHABETICAL,
+                    locationSortOrder=SelectionSortOrder.ALPHABETICAL,
+                    format=0,
+                    legacyDatafeedFileStructure=False,
+                    variables=[],
+                    regions=[],
+                    listingType=ListingType.SHARED,
+                    isDataFeed=False,
+                    startYear=2015,
+                    endYear=2035,
+                    precision=5,
+                    frequency=Frequency.ANNUAL,
+                    stackedQuarters=False,
+                )
+            ],
+            format=FileFormat.CSV,
+        )
+
+    def test_init_client_with_api_key(self, client):
+        assert client.api_key == "test_api_key"
+        assert isinstance(client.raw, httpx.AsyncClient)
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_download_file_with_request_model(
+        self, mock_post, client, download_request
+    ):
+        mock_post.return_value = AsyncMock(status_code=200, content=b"mock content")
+
+        response = await client.download_file_with_request_model(
+            request=download_request
+        )
+
+        assert response == b"mock content"
+        mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.get")
+    async def test_download_file_with_selection_id(self, mock_get, client):
+        mock_get.return_value = AsyncMock(status_code=200, content=b"mock content")
+
+        response = await client.download_file_with_selection_id(selection_id="123")
+
+        assert response == b"mock content"
+
+        mock_get.assert_called_once_with(
+            "/filedownload/123",
+            timeout=httpx.USE_CLIENT_DEFAULT,
+            follow_redirects=True,
+        )
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_queue_download_with_request_model(
+        self, mock_post, client, download_request
+    ):
+        mock_post.return_value = AsyncMock(
+            status_code=200,
+            content=b'{"ReadyUrl": "mock_ready_url", "Url": "mock_url"}',
+        )
+
+        response = await client.queue_download_with_request_model(
+            request=download_request
+        )
+
+        assert isinstance(response, QueueDownloadResponse)
+        assert response.ReadyUrl == "mock_ready_url"
+        mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.get")
+    async def test_check_download_ready_with_id(self, mock_get, client):
+        mock_get.return_value = AsyncMock(status_code=200, content=b"true")
+
+        is_ready = await client.check_download_ready_with_id(download_id="123")
+
+        assert is_ready is True
+        mock_get.assert_called_once_with(
+            "/DownloadReady/123", timeout=httpx.USE_CLIENT_DEFAULT
+        )
+
+    def test_resolve_download_timeout(self, client):
+        assert (
+            client._resolve_download_timeout(None)
+            == client.default_download_timeout_seconds
+        )
+        assert client._resolve_download_timeout(120) == 120
+
+    def test_resolve_poll_timeout(self, client):
+        assert client._resolve_poll_timeout(None) == client.default_poll_timeout_seconds
+        assert client._resolve_poll_timeout(300) == 300
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.get")
+    async def test_list_databanks(self, mock_get, client):
+        mock_get.return_value = AsyncMock(
+            status_code=200, content=b'[{"name": "Test Databank"}]'
+        )
+
+        response = await client.list_databanks(as_json=True)
+
+        assert isinstance(response, list)
+        assert response[0]["name"] == "Test Databank"
+        mock_get.assert_called_once_with(
+            "/Databank", timeout=client.default_download_timeout_seconds
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,142 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from oe_databank.client import DatabankClient
+from oe_databank.enums import (
+    FileFormat,
+    Frequency,
+    ListingType,
+    Order,
+    SelectionSortOrder,
+    SelectionType,
+    Sequence,
+)
+from oe_databank.models import FileDownloadRequestDto, QueueDownloadResponse, Selection
+
+
+class TestDatabankClient:
+    @pytest.fixture
+    def client(self):
+        return DatabankClient(api_key="test_api_key")
+
+    @pytest.fixture
+    def download_request(self):
+        return FileDownloadRequestDto(
+            selections=[
+                Selection(
+                    selectionType=SelectionType.QUERY,
+                    isTemporarySelection=True,
+                    databankCode="GCT",
+                    sequence=Sequence.EARLIEST_TO_LATEST,
+                    groupingMode=False,
+                    transposeColumns=False,
+                    order=Order.LOCATION_INDICATOR,
+                    indicatorSortOrder=SelectionSortOrder.ALPHABETICAL,
+                    locationSortOrder=SelectionSortOrder.ALPHABETICAL,
+                    format=0,
+                    legacyDatafeedFileStructure=False,
+                    variables=[
+                        # DownloadRequestVariable(
+                        #     variableCode="MRSA!$",
+                        #     productTypeCode="GCT",
+                        #     measureCodes=[],
+                        # )
+                    ],
+                    regions=[
+                        # DownloadRequestRegion(
+                        #     databankCode="GCT",
+                        #     regionCode="ETH_ADD",
+                        # ),
+                    ],
+                    listingType=ListingType.SHARED,
+                    isDataFeed=False,
+                    startYear=2015,
+                    endYear=2035,
+                    precision=5,
+                    frequency=Frequency.ANNUAL,
+                    stackedQuarters=False,
+                )
+            ],
+            format=FileFormat.CSV,
+        )
+
+    def test_init_client_with_api_key(self, client):
+        assert client.api_key == "test_api_key"
+        assert isinstance(client.raw, httpx.Client)
+
+    @patch("httpx.Client.post")
+    def test_download_file_with_request_model(
+        self, mock_post, client, download_request
+    ):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.content = b"mock content"
+
+        response = client.download_file_with_request_model(request=download_request)
+
+        assert response == b"mock content"
+        mock_post.assert_called_once()
+
+    @patch("httpx.Client.get")
+    def test_download_file_with_selection_id(self, mock_get, client):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = b"mock content"
+
+        response = client.download_file_with_selection_id(selection_id="123")
+
+        assert response == b"mock content"
+        mock_get.assert_called_once_with(
+            "/filedownload/123",
+            timeout=client.default_download_timeout_seconds,
+            follow_redirects=True,
+        )
+
+    @patch("httpx.Client.post")
+    def test_queue_download_with_request_model(
+        self, mock_post, client, download_request
+    ):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.content = (
+            b'{"ReadyUrl": "mock_ready_url", "Url": "mock_url"}'
+        )
+
+        response = client.queue_download_with_request_model(request=download_request)
+
+        assert isinstance(response, QueueDownloadResponse)
+        assert response.ReadyUrl == "mock_ready_url"
+        mock_post.assert_called_once()
+
+    @patch("httpx.Client.get")
+    def test_check_download_ready_with_id(self, mock_get, client):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = b"true"
+
+        is_ready = client.check_download_ready_with_id(download_id="123")
+
+        assert is_ready is True
+        mock_get.assert_called_once_with("/DownloadReady/123", timeout=None)
+
+    def test_resolve_download_timeout(self, client):
+        assert (
+            client._resolve_download_timeout(None)
+            == client.default_download_timeout_seconds
+        )
+        assert client._resolve_download_timeout(120) == 120
+
+    def test_resolve_poll_timeout(self, client):
+        assert client._resolve_poll_timeout(None) == client.default_poll_timeout_seconds
+        assert client._resolve_poll_timeout(300) == 300
+
+    @patch("httpx.Client.get")
+    def test_list_databanks(self, mock_get, client):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = b'[{"name": "Test Databank"}]'
+
+        response = client.list_databanks(as_json=True)
+
+        assert isinstance(response, list)
+        assert response[0]["name"] == "Test Databank"
+        mock_get.assert_called_once_with(
+            "/Databank", timeout=client.default_download_timeout_seconds
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -161,12 +161,14 @@ dependencies = [
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -175,12 +177,14 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.10.7" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "tenacity", specifier = ">=9.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.0.1" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
 
 [[package]]
@@ -402,6 +406,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -461,6 +477,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
 ]
 
 [[package]]


### PR DESCRIPTION
`httpx` sometimes loses the connection or times out during a download.

```
  File ".venv\Lib\site-packages\httpx\_client.py", line 1776, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\httpx\_transports\default.py", line 376, in handle_async_request
    with map_httpcore_exceptions():
  File "C:\Users\dtarro\AppData\Roaming\uv\python\cpython-3.12.5-windows-x86_64-none\Lib\contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File ".venv\Lib\site-packages\httpx\_transports\default.py", line 89, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ReadTimeout
```

- Fixed with a mechanism in both clients to retry requests only during the download step.
- Added unit tests to test client changes
- Added usage examples for the README
